### PR TITLE
chore: update headings and captions to semi-bold (500) vs bold (700)

### DIFF
--- a/source/stylesheets/contact.sass
+++ b/source/stylesheets/contact.sass
@@ -8,7 +8,7 @@
 
   label
     display: block
-    font: bold 1em var(--sans-serif-font)
+    font: 500 1em var(--sans-serif-font)
     margin-bottom: 8px
 
   input
@@ -34,7 +34,7 @@
       text-decoration: underline
 
   .button
-    font: bold 1em var(--sans-serif-font)
+    font: 500 1em var(--sans-serif-font)
     max-width: 300px
     width: 100%
     margin: 40px auto 0

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -78,7 +78,7 @@ a, button, submit, select, input, .select
 
 h1, h2, h3, h4, h5
   font-family: var(--sans-serif-font)
-  font-weight: bold
+  font-weight: 500
 
 h1
   font-size: 1.8em
@@ -103,7 +103,7 @@ h2
   border-radius: var(--border-radius)
   color: var(--button-text-color)
   min-height: 60px
-  font-weight: bold
+  font-weight: 500
   display: flex
   align-items: center
   justify-content: center
@@ -196,7 +196,7 @@ h2
 .store-name
   font-size: 2em
   display: flex
-  font-weight: bold
+  font-weight: 500
   align-items: center
   text-align: center
   justify-content: center

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -16,7 +16,7 @@
   row-gap: 4px
   flex-wrap: wrap
   font-size: .925em
-  font-weight: bold
+  font-weight: 500
 
   .next-arrow
     width: 5px

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -116,7 +116,7 @@ a.product-list-link
 
 .product-list-thumb-name
   word-break: break-word
-  font: bold 1em var(--sans-serif-font)
+  font: 500 1em var(--sans-serif-font)
 
 .product-list-thumb-price
   font-family: var(--serif-font)


### PR DESCRIPTION
Proposing change for Picklejuice to have button captions, headings, breadcrumbs and product thumbnail names as semi-bold font weight vs bold.  This creates a softer look which I think matches the overall theme styling better by default, as well as being more flexible for different styling based on seller font choices.

![image](https://github.com/user-attachments/assets/806a1721-69d6-448e-9ebc-c42f0e4d492c)
