### PR TITLE
feat: add new color settings for button and link colors

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -59,7 +59,7 @@
               "border_color": "#333333",
               "button_text_color": "#FFFFFF",
               "button_background_color": "#333333",
-              "button_hover_background_color": "#227e13"
+              "button_hover_background_color": "#1028B7"
             }
           }
         ]
@@ -82,7 +82,7 @@
               "border_color": "#333333",
               "button_text_color": "#FFFFFF",
               "button_background_color": "#333333",
-              "button_hover_background_color": "#227e13"
+              "button_hover_background_color": "#5900FF"
             }
           }
         ]
@@ -105,7 +105,7 @@
               "border_color": "#333333",
               "button_text_color": "#FFFFFF",
               "button_background_color": "#333333",
-              "button_hover_background_color": "#227e13"
+              "button_hover_background_color": "#584B53"
             }
           },
           {
@@ -123,7 +123,7 @@
               "border_color": "#333333",
               "button_text_color": "#FFFFFF",
               "button_background_color": "#333333",
-              "button_hover_background_color": "#227e13"
+              "button_hover_background_color": "#8A5A5A"
             }
           }
         ]
@@ -183,7 +183,6 @@
       "label": "Button hover background",
       "default": "#227e13"
     },
-    
     {
       "variable": "border_color",
       "label": "Borders",
@@ -200,8 +199,9 @@
     "background_color": "{{ background_color }}",
     "body_font": "{{ primary_font }}",
     "input_border_radius": "0px",
-    "button_background_color": "#333",
-    "button_hover_background_color": "{{ secondary_color }}",
+    "button_text_color": "{{ button_text_color }}",
+    "button_background_color": "{{ button_background_color }}",
+    "button_hover_background_color": "{{ button_hover_background_color }}",
     "button_border_radius": "0px",
     "link_color": "{{ secondary_color }}"
   },

--- a/source/settings.json
+++ b/source/settings.json
@@ -34,10 +34,14 @@
             },
             "colors": {
               "background_color": "#DBF1DA",
+              "link_color": "#000000",
               "link_hover_color": "#227e13",
               "text_color": "#000000",
               "accent_background_color": "#FFFFFF",
-              "border_color": "#333333"
+              "border_color": "#333333",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#333333",
+              "button_hover_background_color": "#227e13"
             }
           },
           {
@@ -48,10 +52,14 @@
             },
             "colors": {
               "background_color": "#E6F3FF",
+              "link_color": "#000000",
               "link_hover_color": "#1028B7",
               "text_color": "#000000",
               "accent_background_color": "#FFFFFF",
-              "border_color": "#333333"
+              "border_color": "#333333",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#333333",
+              "button_hover_background_color": "#227e13"
             }
           }
         ]
@@ -67,10 +75,14 @@
             },
             "colors": {
               "background_color": "#FFFFFF",
+              "link_color": "#000000",
               "link_hover_color": "#5900FF",
               "text_color": "#000000",
               "accent_background_color": "#FFFFFF",
-              "border_color": "#333333"
+              "border_color": "#333333",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#333333",
+              "button_hover_background_color": "#227e13"
             }
           }
         ]
@@ -86,10 +98,14 @@
             },
             "colors": {
               "background_color": "#FEF5EF",
+              "link_color": "#000000",
               "link_hover_color": "#584B53",
               "text_color": "#000000",
               "accent_background_color": "#FFFFFF",
-              "border_color": "#333333"
+              "border_color": "#333333",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#333333",
+              "button_hover_background_color": "#227e13"
             }
           },
           {
@@ -100,10 +116,14 @@
             },
             "colors": {
               "background_color": "#F1F1F1",
+              "link_color": "#000000",
               "link_hover_color": "#8A5A5A",
               "text_color": "#000000",
               "accent_background_color": "#FFFFFF",
-              "border_color": "#333333"
+              "border_color": "#333333",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#333333",
+              "button_hover_background_color": "#227e13"
             }
           }
         ]
@@ -139,10 +159,31 @@
       "default": "#000000"
     },
     {
+      "variable": "link_color",
+      "label": "Link",
+      "default": "#000000"
+    },
+    {
       "variable": "link_hover_color",
       "label": "Link hover",
       "default": "#227e13"
     },
+    {
+      "variable": "button_text_color",
+      "label": "Button text",
+      "default": "#FFFFFF"
+    },
+    {
+      "variable": "button_background_color",
+      "label": "Button background",
+      "default": "#000000"
+    },
+    {
+      "variable": "button_hover_background_color",
+      "label": "Button hover background",
+      "default": "#227e13"
+    },
+    
     {
       "variable": "border_color",
       "label": "Borders",

--- a/source/stylesheets/_variables.sass
+++ b/source/stylesheets/_variables.sass
@@ -13,9 +13,9 @@
   --sans-serif-font: #{'{{ theme.primary_font | font_family }}'}
   --serif-font: #{'{{ theme.secondary_font | font_family }}'}
 
-  --button-text-color: var(--button-text-color)
-  --button-background-color: var(--button-background-color)
-  --button-background-hover-color: var(--button-hover-background-color)
+  --button-text-color: #{'{{ theme.button_text_color }}'}
+  --button-background-color: #{'{{ theme.button_background_color }}'}
+  --button-hover-background-color: #{'{{ theme.button_hover_background_color }}'}
 
   --product-status-text-color: var(--accent-background-color)
   --product-status-background-color: var(--border-color)

--- a/source/stylesheets/_variables.sass
+++ b/source/stylesheets/_variables.sass
@@ -3,6 +3,7 @@
   --text-color: #{'{{ theme.text_color }}'}
   --accent-background-color: #{'{{ theme.accent_background_color }}'}
   --border-color: #{'{{ theme.border_color }}'}
+  --link-color: #{'{{ theme.link_color }}'}
   --link-hover-color: #{'{{ theme.link_hover_color }}'}
   --light-gray-color: #{'rgba(var(--border-color-rgb), .2)'}
 
@@ -12,9 +13,9 @@
   --sans-serif-font: #{'{{ theme.primary_font | font_family }}'}
   --serif-font: #{'{{ theme.secondary_font | font_family }}'}
 
-  --button-text-color: var(--accent-background-color)
-  --button-background-color: var(--border-color)
-  --button-background-hover-color: var(--link-hover-color)
+  --button-text-color: var(--button-text-color)
+  --button-background-color: var(--button-background-color)
+  --button-background-hover-color: var(--button-hover-background-color)
 
   --product-status-text-color: var(--accent-background-color)
   --product-status-background-color: var(--border-color)

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -2,7 +2,7 @@
   box-sizing: border-box
 
 a
-  color: var(--text-color)
+  color: var(--link-color)
   text-decoration: none
 
   &:hover
@@ -62,7 +62,7 @@ a.skip-link
   +transition(all .3s)
   background: var(--background-color)
   border: 1px solid var(--text-color)
-  color: var(--text-color)
+  color: var(--link-color)
   left: 25px
   padding: 15px 20px
   position: absolute

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -136,7 +136,7 @@ h2
     margin: 60px auto
 
   &:not(:disabled):hover, &:not(:disabled):active
-    background: var(--button-background-hover-color)
+    background: var(--button-hover-background-color)
     color: var(--button-text-color)
 
 .select

--- a/source/stylesheets/search.sass
+++ b/source/stylesheets/search.sass
@@ -69,7 +69,7 @@
     justify-content: center
 
     &:hover, &:focus
-      background: var(--button-background-hover-color)
+      background: var(--button-hover-background-color)
 
   &__close
     display: flex


### PR DESCRIPTION
Adds new settings for:

- Button text color
- Button Background color
- Button Hover Background color
- Link color

Previoulsy these were all set to inherit from either link hover or border colors. This gives more control while still having the same original default color values.