### PR TITLE
Picklejuice 3.11.1

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -1227,7 +1227,7 @@
       "section": "translations",
       "sub_section": "homepage",
       "type": "text",
-      "default": "Featured categories",
+      "default": "Shop by Category",
       "allow_blank": true,
       "description": "Text for the featured categories section on the home page.",
       "requires": [ "translation_mode eq manual" ]

--- a/source/settings.json
+++ b/source/settings.json
@@ -1325,6 +1325,26 @@
       "requires": [ "translation_mode eq manual" ]
     },
     {
+      "variable": "products_product_tr_text",
+      "label": "'Product'",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "default": "Product",
+      "description": "Text displayed when referencing a single item in your shop",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_products_tr_text",
+      "label": "'Products'",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "default": "Products",
+      "description": "Text displayed when referencing multiple items in your shop",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
       "variable": "products_related_products_tr_text",
       "label": "Related products header",
       "section": "translations",

--- a/source/settings.json
+++ b/source/settings.json
@@ -829,7 +829,8 @@
       "label": "Show product variant count in product grids",
       "section": "product_page",
       "type": "boolean",
-      "default": false,
+      "default": true,
+      "upgrade_default": false,
       "description": "For products with multiple variants, show the variant count in product grids."
     },
     {

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "PickleJuice",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "images": [
     {
       "variable": "logo",


### PR DESCRIPTION
- chore: variant count in product grids by default on for new themes
- chore: featured categories default text
- chore: product(s) labels translations